### PR TITLE
Make things compile on GHC 7.7

### DIFF
--- a/Data/Proxy.hs
+++ b/Data/Proxy.hs
@@ -38,6 +38,10 @@ import GHC.Arr (unsafeIndex, unsafeRangeSize)
 import Data.Data
 #endif
 
+#if __GLASGOW_HASKELL__ >= 707
+import Data.Data (Proxy)
+
+#else
 data Proxy s = Proxy
 
 instance Eq (Proxy s) where
@@ -53,6 +57,7 @@ instance Read (Proxy s) where
   readsPrec d = readParen (d > 10) (\r -> [(Proxy, s) | ("Proxy",s) <- lex r ])
 
 #ifdef __GLASGOW_HASKELL__
+#if __GLASGOW_HASKELL__ < 707
 
 instance Typeable1 Proxy where
   typeOf1 _ = mkTyConApp proxyTyCon []
@@ -64,6 +69,7 @@ proxyTyCon = mkTyCon "Data.Proxy.Proxy"
 proxyTyCon = mkTyCon3 "tagged" "Data.Proxy" "Proxy"
 #endif
 {-# NOINLINE proxyTyCon #-}
+#endif
 
 instance Data s => Data (Proxy s) where
   gfoldl _ z _ = z Proxy
@@ -156,6 +162,8 @@ instance Traversable Proxy where
     sequence _ = return Proxy
     {-# INLINE sequence #-}
 
+#endif
+
 -- | Some times you need to change the proxy you have lying around.
 -- Idiomatic usage is to make a new combinator for the relationship
 -- between the proxies that you want to enforce, and define that
@@ -187,3 +195,4 @@ unproxy f = Tagged (f Proxy)
 asProxyTypeOf :: a -> Proxy a -> a
 asProxyTypeOf = const
 {-# INLINE asProxyTypeOf #-}
+

--- a/Data/Tagged.hs
+++ b/Data/Tagged.hs
@@ -48,9 +48,13 @@ import Data.Monoid
 -- argument, because the newtype is \"free\"
 newtype Tagged s b = Tagged { unTagged :: b } deriving
   ( Eq, Ord, Ix, Bounded
+#if __GLASGOW_HASKELL__ >= 707
+  , Typeable
+#endif
   )
 
 #ifdef __GLASGOW_HASKELL__
+#if __GLASGOW_HASKELL__ < 707
 instance Typeable2 Tagged where
   typeOf2 _ = mkTyConApp taggedTyCon []
 
@@ -59,6 +63,8 @@ taggedTyCon :: TyCon
 taggedTyCon = mkTyCon "Data.Tagged.Tagged"
 #else
 taggedTyCon = mkTyCon3 "tagged" "Data.Tagged" "Tagged"
+#endif
+
 #endif
 
 instance (Data s, Data b) => Data (Tagged s b) where


### PR DESCRIPTION
I can't in good conscience suggest that this terrible hack be merged, but I'll open this pull request just to note that the problem exists. I'm not really sure how to properly handle the conflict with `Data.Data.Proxy` but this compiles and appears to work. Hopefully someone else will be able to clean it up eventually.
