### PR TITLE
Fixes duplicate instance errors when compiling with current GHC HEAD.

### DIFF
--- a/Data/Proxy.hs
+++ b/Data/Proxy.hs
@@ -45,11 +45,8 @@ import GHC.Arr (unsafeIndex, unsafeRangeSize)
 import Data.Data
 #endif
 
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 707
-deriving instance Typeable Proxy
-#else
+#if !defined(__GLASGOW_HASKELL__) || __GLASGOW_HASKELL__ < 707
 data Proxy s = Proxy
-#endif
 
 instance Eq (Proxy s) where
   _ == _ = True
@@ -62,6 +59,7 @@ instance Show (Proxy s) where
 
 instance Read (Proxy s) where
   readsPrec d = readParen (d > 10) (\r -> [(Proxy, s) | ("Proxy",s) <- lex r ])
+#endif
 
 #ifdef __GLASGOW_HASKELL__
 #if __GLASGOW_HASKELL__ < 707
@@ -75,7 +73,6 @@ proxyTyCon = mkTyCon "Data.Proxy.Proxy"
 proxyTyCon = mkTyCon3 "tagged" "Data.Proxy" "Proxy"
 #endif
 {-# NOINLINE proxyTyCon #-}
-#endif
 
 instance Data s => Data (Proxy s) where
   gfoldl _ z _ = z Proxy
@@ -85,6 +82,7 @@ instance Data s => Data (Proxy s) where
     _ -> error "gunfold"
   dataTypeOf _ = proxyDataType
   dataCast1 f = gcast1 f
+#endif
 
 proxyConstr :: Constr
 proxyConstr = mkConstr proxyDataType "Proxy" [] Prefix
@@ -95,6 +93,7 @@ proxyDataType = mkDataType "Data.Proxy.Proxy" [proxyConstr]
 {-# NOINLINE proxyDataType #-}
 #endif
 
+#if !defined(__GLASGOW_HASKELL__) || __GLASGOW_HASKELL__ < 707
 instance Enum (Proxy s) where
     succ _ = error "Proxy.succ"
     pred _ = error "Proxy.pred"
@@ -167,6 +166,7 @@ instance Traversable Proxy where
     {-# INLINE mapM #-}
     sequence _ = return Proxy
     {-# INLINE sequence #-}
+#endif
 
 -- | Some times you need to change the proxy you have lying around.
 -- Idiomatic usage is to make a new combinator for the relationship


### PR DESCRIPTION
It seems these are defined in base Data.Proxy now.
