### PR TITLE
Define KProxy, Generic instances for base compatibility

### DIFF
--- a/old/Data/Proxy.hs
+++ b/old/Data/Proxy.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE KindSignatures #-}
 #ifdef LANGUAGE_DeriveDataTypeable
 {-# LANGUAGE DeriveDataTypeable #-}
 #endif
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 706
+{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE PolyKinds #-}
 #endif
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 707
@@ -182,4 +182,10 @@ asProxyTypeOf = const
 
 -- | A concrete, promotable proxy type, for use at the kind level
 -- There are no instances for this because it is intended at the kind level only
-data KProxy (t :: *) = KProxy
+data KProxy 
+#if __GLASGOW_HASKELL__ >= 706
+            (t :: *)
+#else
+            t
+#endif
+    = KProxy

--- a/old/Data/Proxy.hs
+++ b/old/Data/Proxy.hs
@@ -183,7 +183,7 @@ asProxyTypeOf = const
 -- | A concrete, promotable proxy type, for use at the kind level
 -- There are no instances for this because it is intended at the kind level only
 data KProxy 
-#if __GLASGOW_HASKELL__ >= 706
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 706
             (t :: *)
 #else
             t

--- a/old/Data/Proxy.hs
+++ b/old/Data/Proxy.hs
@@ -189,3 +189,6 @@ data KProxy
             t
 #endif
     = KProxy
+#if defined(LANGUAGE_DeriveDataTypeable)
+  deriving Typeable
+#endif

--- a/old/Data/Proxy.hs
+++ b/old/Data/Proxy.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE KindSignatures #-}
 #ifdef LANGUAGE_DeriveDataTypeable
 {-# LANGUAGE DeriveDataTypeable #-}
 #endif
@@ -9,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 #endif
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE Trustworthy #-}
 #endif
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -28,6 +30,7 @@ module Data.Proxy
     -- * Proxy values
       Proxy(..)
     , asProxyTypeOf
+    , KProxy(..)
     ) where
 
 import Control.Applicative (Applicative(..))
@@ -38,12 +41,18 @@ import Data.Monoid
 #ifdef __GLASGOW_HASKELL__
 import GHC.Arr (unsafeIndex, unsafeRangeSize)
 import Data.Data
+#if __GLASGOW_HASKELL__ >= 702
+import GHC.Generics (Generic)
+#endif
 #endif
 
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 707
 deriving instance Typeable Proxy
 #else
 data Proxy s = Proxy
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
+  deriving Generic
+#endif
 #endif
 
 instance Eq (Proxy s) where
@@ -170,3 +179,7 @@ instance Traversable Proxy where
 asProxyTypeOf :: a -> proxy a -> a
 asProxyTypeOf = const
 {-# INLINE asProxyTypeOf #-}
+
+-- | A concrete, promotable proxy type, for use at the kind level
+-- There are no instances for this because it is intended at the kind level only
+data KProxy (t :: *) = KProxy

--- a/src/Data/Tagged.hs
+++ b/src/Data/Tagged.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE PolyKinds #-}
 #endif
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE Trustworthy #-}
 #endif
 ----------------------------------------------------------------------------
@@ -53,6 +54,9 @@ import Data.Monoid
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ < 707
 import Data.Proxy
 #endif
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
+import GHC.Generics (Generic, Generic1)
+#endif
 
 -- | A @'Tagged' s b@ value is a value @b@ with an attached phantom type @s@.
 -- This can be used in place of the more traditional but less safe idiom of
@@ -63,8 +67,18 @@ import Data.Proxy
 -- argument, because the newtype is \"free\"
 newtype Tagged s b = Tagged { unTagged :: b } deriving
   ( Eq, Ord, Ix, Bounded
+#ifdef __GLASGOW_HASKELL__
+#if __GLASGOW_HASKELL__ >= 702
+  , Generic
+#if __GLASGOW_HASKELL__ >= 706
+  , Generic1
+#endif
+#endif
+
 #if __GLASGOW_HASKELL__ >= 707
   , Typeable
+#endif
+
 #endif
   )
 

--- a/src/Data/Tagged.hs
+++ b/src/Data/Tagged.hs
@@ -55,7 +55,10 @@ import Data.Monoid
 import Data.Proxy
 #endif
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
-import GHC.Generics (Generic, Generic1)
+import GHC.Generics (Generic)
+#if __GLASGOW_HASKELL__ >= 706
+import GHC.Generics (Generic1)
+#endif
 #endif
 
 -- | A @'Tagged' s b@ value is a value @b@ with an attached phantom type @s@.

--- a/tagged.cabal
+++ b/tagged.cabal
@@ -36,6 +36,9 @@ library
     exposed-modules: Data.Proxy
     other-modules: Paths_tagged
 
+  if impl(ghc>=7.2 && <7.5)
+    build-depends: ghc-prim
+
   if impl(ghc>=7.6)
     exposed-modules: Data.Proxy.TH
     build-depends: template-haskell >= 2.8 && < 2.11


### PR DESCRIPTION
There's currently some discrepancies between the `Data.Proxy` modules provided by `base` and `tagged`, so I retrofitted `old/Data/Proxy.hs` with the missing features:

* Added a `KProxy` data type
* `Proxy` has a derived `Generic` instance

Since there's a `Generic (Proxy s)` instance now, I went ahead and added `Generic` and `Generic1` instances for `Tagged` as well.

I didn't create a `Generic1 Proxy` instance since (1) `base` doesn't define one and (2) `data Proxy s = Proxy deriving Generic1` breaks on GHC 7.6 due to a strange bug with `PolyKinds`. If `base` ever decides to define a `Generic1` instance, I suppose a `Generic1 Proxy` instance could be defined by hand to get around this.