### PR TITLE
Add note about PolyKinds

### DIFF
--- a/src/Data/Tagged.hs
+++ b/src/Data/Tagged.hs
@@ -74,6 +74,9 @@ import GHC.Generics (Generic1)
 --
 -- Moreover, you don't have to rely on the compiler to inline away the extra
 -- argument, because the newtype is \"free\"
+--
+-- 'Tagged' has kind @k -> * -> *@, if compiler supports @PolyKinds@, that for
+-- there is an extra @k@ in instance haddocks.
 newtype Tagged s b = Tagged { unTagged :: b } deriving
   ( Eq, Ord, Ix, Bounded
 #if __GLASGOW_HASKELL__ >= 702


### PR DESCRIPTION
That might prevent similar confusion I had (in haddock it's just `Tagged s b`, not `Tagged (s :: k) b`. Also instances list looks confusing: e.g. `Traversable (Tagged k s)`.