### PR TITLE
Backport NFData instance from deepseq

### DIFF
--- a/old/Data/Proxy.hs
+++ b/old/Data/Proxy.hs
@@ -34,6 +34,9 @@ module Data.Proxy
     ) where
 
 import Control.Applicative (Applicative(..))
+#ifdef MIN_VERSION_deepseq
+import Control.DeepSeq (NFData(..))
+#endif
 import Data.Traversable (Traversable(..))
 import Data.Foldable (Foldable(..))
 import Data.Ix (Ix(..))
@@ -123,6 +126,11 @@ instance Ix (Proxy s) where
 instance Bounded (Proxy s) where
     minBound = Proxy
     maxBound = Proxy
+
+#ifdef MIN_VERSION_deepseq
+instance NFData (Proxy s) where
+    rnf Proxy = ()
+#endif
 
 instance Functor Proxy where
     fmap _ _ = Proxy

--- a/src/Data/Tagged.hs
+++ b/src/Data/Tagged.hs
@@ -49,6 +49,9 @@ import Data.Traversable (Traversable(..))
 import Data.Monoid
 #endif
 import Data.Foldable (Foldable(..))
+#ifdef MIN_VERSION_deepseq
+import Control.DeepSeq (NFData(..))
+#endif
 import Control.Monad (liftM)
 #if __GLASGOW_HASKELL__ >= 709
 import Data.Bifunctor
@@ -147,6 +150,11 @@ instance Functor (Tagged s) where
 instance Bifunctor Tagged where
     bimap _ g (Tagged b) = Tagged (g b)
     {-# INLINE bimap #-}
+#endif
+
+#ifdef MIN_VERSION_deepseq
+instance NFData b => NFData (Tagged s b) where
+    rnf (Tagged b) = rnf b
 #endif
 
 instance Applicative (Tagged s) where

--- a/tagged.cabal
+++ b/tagged.cabal
@@ -19,6 +19,14 @@ source-repository head
   type: git
   location: git://github.com/ekmett/tagged.git
 
+flag deepseq
+  description:
+    You can disable the use of the `deepseq` package using `-f-deepseq`.
+    .
+    Disabing this is an unsupported configuration, but it may be useful for accelerating builds in sandboxes for expert users.
+  default: True
+  manual: True
+
 library
   default-language: Haskell98
   other-extensions: CPP
@@ -42,3 +50,6 @@ library
   if impl(ghc>=7.6)
     exposed-modules: Data.Proxy.TH
     build-depends: template-haskell >= 2.8 && < 2.11
+
+  if flag(deepseq)
+    build-depends: deepseq >= 1.1 && < 1.5


### PR DESCRIPTION
I didn't realize until recently that `deepseq` has an `NFData (Proxy t)` instance when `Proxy` is in `base`, so I backported that instance to `tagged`. I also added an `NFData (Tagged s b)` instance as a bonus.