### PR TITLE
Fix MRP warnings

### DIFF
--- a/src/Data/Tagged.hs
+++ b/src/Data/Tagged.hs
@@ -162,13 +162,15 @@ instance Applicative (Tagged s) where
     {-# INLINE pure #-}
     Tagged f <*> Tagged x = Tagged (f x)
     {-# INLINE (<*>) #-}
+    _ *> n = n
+    {-# INLINE (*>) #-}
 
 instance Monad (Tagged s) where
-    return = Tagged
+    return = pure
     {-# INLINE return #-}
     Tagged m >>= k = k m
     {-# INLINE (>>=) #-}
-    _ >> n = n
+    (>>) = (*>)
     {-# INLINE (>>) #-}
 
 instance Foldable (Tagged s) where


### PR DESCRIPTION
Noticed this while testing new preliminary code for detecting MRP violations:

    Configuring tagged-0.8.2...
    Building tagged-0.8.2...
    Preprocessing library tagged-0.8.2...
    [1 of 2] Compiling Data.Proxy.TH    ( src/Data/Proxy/TH.hs, dist/build/Data/Proxy/TH.o )
    [2 of 2] Compiling Data.Tagged      ( src/Data/Tagged.hs, dist/build/Data/Tagged.o )

    src/Data/Tagged.hs:(166,1)-(172,23): warning: MRP: return /= pure

    src/Data/Tagged.hs:(166,1)-(172,23): warning: MRP: (>>) /= (*>)
    In-place registering tagged-0.8.2...