### PR TITLE
Backport Data.Functor.Classes instances

### DIFF
--- a/old/Data/Proxy.hs
+++ b/old/Data/Proxy.hs
@@ -39,6 +39,9 @@ import Control.Applicative (Applicative(..))
 #ifdef MIN_VERSION_deepseq
 import Control.DeepSeq (NFData(..))
 #endif
+#ifdef MIN_VERSION_transformers
+import Data.Functor.Classes (Eq1(..), Ord1(..), Read1(..), Show1(..))
+#endif
 import Data.Traversable (Traversable(..))
 import Data.Foldable (Foldable(..))
 import Data.Ix (Ix(..))
@@ -153,6 +156,35 @@ instance Bounded (Proxy s) where
 #ifdef MIN_VERSION_deepseq
 instance NFData (Proxy s) where
     rnf Proxy = ()
+#endif
+
+#ifdef MIN_VERSION_transformers
+# if MIN_VERSION_transformers(0,4,0) && !(MIN_VERSION_transformers(0,5,0))
+instance Eq1 Proxy where
+  eq1 = (==)
+
+instance Ord1 Proxy where
+  compare1 = compare
+
+instance Read1 Proxy where
+  readsPrec1 = readsPrec
+
+instance Show1 Proxy where
+  showsPrec1 = showsPrec
+# else
+instance Eq1 Proxy where
+  liftEq _ _ _ = True
+
+instance Ord1 Proxy where
+  liftCompare _ _ _ = EQ
+
+instance Show1 Proxy where
+  liftShowsPrec _ _ _ _ = showString "Proxy"
+
+instance Read1 Proxy where
+  liftReadsPrec _ _ d =
+    readParen (d > 10) (\r -> [(Proxy, s) | ("Proxy",s) <- lex r ])
+# endif
 #endif
 
 instance Functor Proxy where

--- a/src/Data/Tagged.hs
+++ b/src/Data/Tagged.hs
@@ -52,6 +52,13 @@ import Data.Foldable (Foldable(..))
 #ifdef MIN_VERSION_deepseq
 import Control.DeepSeq (NFData(..))
 #endif
+#ifdef MIN_VERSION_transformers
+import Data.Functor.Classes ( Eq1(..), Ord1(..), Read1(..), Show1(..)
+# if !(MIN_VERSION_transformers(0,4,0)) || MIN_VERSION_transformers(0,5,0)
+                            , Eq2(..), Ord2(..), Read2(..), Show2(..)
+# endif
+                            )
+#endif
 import Control.Monad (liftM)
 #if __GLASGOW_HASKELL__ >= 709
 import Data.Bifunctor
@@ -168,6 +175,52 @@ instance Bifunctor Tagged where
 #ifdef MIN_VERSION_deepseq
 instance NFData b => NFData (Tagged s b) where
     rnf (Tagged b) = rnf b
+#endif
+
+#ifdef MIN_VERSION_transformers
+# if MIN_VERSION_transformers(0,4,0) && !(MIN_VERSION_transformers(0,5,0))
+instance Eq1 (Tagged s) where
+    eq1 = (==)
+
+instance Ord1 (Tagged s) where
+    compare1 = compare
+
+instance Read1 (Tagged s) where
+    readsPrec1 = readsPrec
+
+instance Show1 (Tagged s) where
+    showsPrec1 = showsPrec
+# else
+instance Eq1 (Tagged s) where
+    liftEq eq (Tagged a) (Tagged b) = eq a b
+
+instance Ord1 (Tagged s) where
+    liftCompare cmp (Tagged a) (Tagged b) = cmp a b
+
+instance Read1 (Tagged s) where
+    liftReadsPrec rp _ d = readParen (d > 10) $ \r ->
+        [(Tagged a, t) | ("Tagged", s) <- lex r, (a, t) <- rp 11 s]
+
+instance Show1 (Tagged s) where
+    liftShowsPrec sp _ n (Tagged b) = showParen (n > 10) $
+        showString "Tagged " .
+        sp 11 b
+
+instance Eq2 Tagged where
+    liftEq2 _ eq (Tagged a) (Tagged b) = eq a b
+
+instance Ord2 Tagged where
+    liftCompare2 _ cmp (Tagged a) (Tagged b) = cmp a b
+
+instance Read2 Tagged where
+    liftReadsPrec2 _ _ rp _ d = readParen (d > 10) $ \r ->
+        [(Tagged a, t) | ("Tagged", s) <- lex r, (a, t) <- rp 11 s]
+
+instance Show2 Tagged where
+    liftShowsPrec2 _ _ sp _ n (Tagged b) = showParen (n > 10) $
+        showString "Tagged " .
+        sp 11 b
+# endif
 #endif
 
 instance Applicative (Tagged s) where

--- a/tagged.cabal
+++ b/tagged.cabal
@@ -27,6 +27,14 @@ flag deepseq
   default: True
   manual: True
 
+flag transformers
+  description:
+    You can disable the use of the `transformers` and `transformers-compat` packages using `-f-transformers`.
+    .
+    Disable this is an unsupported configuration, but it may be useful for accelerating builds in sandboxes for expert users.
+  default: True
+  manual: True
+
 library
   default-language: Haskell98
   other-extensions: CPP
@@ -53,3 +61,7 @@ library
 
   if flag(deepseq)
     build-depends: deepseq >= 1.1 && < 1.5
+
+  if flag(transformers)
+    build-depends: transformers        >= 0.2 && < 0.6,
+                   transformers-compat >= 0.5 && < 1


### PR DESCRIPTION
Backports the `Eq1`, `Ord1`, etc. instances for `Proxy` introduced in http://git.haskell.org/ghc.git/commit/5097f3802124cfbe6810bff8110df91d4c52096b. Also adds the corresponding instances for `Tagged`.

See also #36.