### PR TITLE
Bumped upper version bound for template-haskell

### DIFF
--- a/tagged.cabal
+++ b/tagged.cabal
@@ -57,7 +57,7 @@ library
 
   if impl(ghc>=7.6)
     exposed-modules: Data.Proxy.TH
-    build-depends: template-haskell >= 2.8 && < 2.13
+    build-depends: template-haskell >= 2.8 && < 2.14
 
   if flag(deepseq)
     build-depends: deepseq >= 1.1 && < 1.5


### PR DESCRIPTION
GHC 8.4.1-alpha1 was [announced](https://mail.haskell.org/pipermail/ghc-devs/2017-December/015235.html). While testing [Agda](https://github.com/agda/agda) with this version of GHC, I got an error related to the versions allowed of template-haskell.

This PR fix this issue.

Blocking https://github.com/agda/agda/issues/2878. 