### PR TITLE
Tidy up dependencies

### DIFF
--- a/tagged.cabal
+++ b/tagged.cabal
@@ -72,5 +72,6 @@ library
     build-depends: deepseq >= 1.1 && < 1.5
 
   if flag(transformers)
-    build-depends: transformers        >= 0.2 && < 0.6,
-                   transformers-compat >= 0.5 && < 1
+    build-depends: transformers        >= 0.2 && < 0.6
+    if !impl(ghc > 7.8)
+      build-depends: transformers-compat >= 0.5 && < 1


### PR DESCRIPTION
This removes a dependency on `transformers-compat` for older versions of GHC.