### PR TITLE
Relax template-haskell upper bound

### DIFF
--- a/tagged.cabal
+++ b/tagged.cabal
@@ -69,7 +69,7 @@ library
 
   if impl(ghc>=7.6)
     exposed-modules: Data.Proxy.TH
-    build-depends: template-haskell >= 2.8 && < 2.17
+    build-depends: template-haskell >= 2.8 && < 2.18
 
   if flag(deepseq)
     build-depends: deepseq >= 1.1 && < 1.5


### PR DESCRIPTION
Current GHC HEAD, which will soon be released as GHC 9 comes with template-haskell 2.17. The code compiles without any modification with it, so this PR just relaxes the upper bound.