### PR TITLE
Use -Winferred-safe-imports with GHC-9.0+

### DIFF
--- a/tagged.cabal
+++ b/tagged.cabal
@@ -55,7 +55,9 @@ library
   hs-source-dirs: src
   exposed-modules: Data.Tagged
 
-  if impl(ghc >= 8.10)
+  if impl(ghc >= 9.0)
+    -- these flags may abort compilation with GHC-8.10
+    -- https://gitlab.haskell.org/ghc/ghc/-/merge_requests/3295
     ghc-options: -Winferred-safe-imports -Wmissing-safe-haskell-mode
 
   if !impl(hugs)


### PR DESCRIPTION
I think this way is better.

If you could make a release then, so I can rely on the explicitly-safe-tagged in `semigroupoids` and `profunctors`