### PR TITLE
Drop the transformers dependency

### DIFF
--- a/src/Data/Tagged.hs
+++ b/src/Data/Tagged.hs
@@ -42,13 +42,9 @@ import Data.Foldable (Foldable(..))
 #ifdef MIN_VERSION_deepseq
 import Control.DeepSeq (NFData(..))
 #endif
-#ifdef MIN_VERSION_transformers
 import Data.Functor.Classes ( Eq1(..), Ord1(..), Read1(..), Show1(..)
-# if !(MIN_VERSION_transformers(0,4,0)) || MIN_VERSION_transformers(0,5,0)
                             , Eq2(..), Ord2(..), Read2(..), Show2(..)
-# endif
                             )
-#endif
 import Control.Monad (liftM)
 import Data.Bifunctor
 #if MIN_VERSION_base(4,10,0)
@@ -154,7 +150,6 @@ instance NFData b => NFData (Tagged s b) where
     rnf (Tagged b) = rnf b
 #endif
 
-#ifdef MIN_VERSION_transformers
 instance Eq1 (Tagged s) where
     liftEq eq (Tagged a) (Tagged b) = eq a b
 
@@ -184,7 +179,6 @@ instance Show2 Tagged where
     liftShowsPrec2 _ _ sp _ n (Tagged b) = showParen (n > 10) $
         showString "Tagged " .
         sp 11 b
-#endif
 
 instance Applicative (Tagged s) where
     pure = Tagged

--- a/tagged.cabal
+++ b/tagged.cabal
@@ -41,14 +41,6 @@ flag deepseq
   default: True
   manual: True
 
-flag transformers
-  description:
-    You can disable the use of the `transformers` and `transformers-compat` packages using `-f-transformers`.
-    .
-    Disable this is an unsupported configuration, but it may be useful for accelerating builds in sandboxes for expert users.
-  default: True
-  manual: True
-
 library
   default-language: Haskell98
   other-extensions: CPP
@@ -68,6 +60,3 @@ library
 
   if flag(deepseq)
     build-depends: deepseq >= 1.1 && < 1.6
-
-  if flag(transformers)
-    build-depends: transformers >= 0.4.2.0 && < 0.7


### PR DESCRIPTION
It was required for Data.Functor.Classes, which is in base since the current minimum supported version (4.9).