### PR TITLE
Deprecate `Data.Proxy.TH`

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,9 @@
 next [????.??.??]
 -----------------
+* Deprecate `Data.Proxy.TH.{pr,pr1}`, as their functionality has been subsumed
+  by using `Proxy` with `TypeApplications` syntax. For instance, uses of
+  `[pr|T|]` should be migrated to `Proxy @T`. `Data.Proxy.TH` will be removed
+  in the next `tagged` release.
 * Allow disabling the `template-haskell` dependency by disabling a `cabal` flag
   of the same name.
 

--- a/src/Data/Proxy/TH.hs
+++ b/src/Data/Proxy/TH.hs
@@ -37,6 +37,12 @@ proxyPatQ t = sigP (conP proxy_d []) (proxyTypeQ t)
 -- @Proxy :: Proxy [A,B,C]@.
 
 -- TODO: parse a richer syntax for the types involved here so we can include spaces, applications, etc.
+{-# DEPRECATED
+      pr
+      [ "'pr' will be removed in the next release. Use 'Proxy' with @TypeApplications@ instead. "
+      , "Instead of using @[pr|T|]@, use @Proxy \\@T@ instead. "
+      , "Instead of using @[pr|A,B,C|]@, use @Proxy \\@[A,B,C]@ instead. "
+      ] #-}
 pr :: QuasiQuoter
 pr = QuasiQuoter (mkProxy proxyExpQ) (mkProxy proxyPatQ) (mkProxy proxyTypeQ) undefined where
   mkProxy :: (TypeQ -> r) -> String -> r
@@ -56,6 +62,11 @@ pr = QuasiQuoter (mkProxy proxyExpQ) (mkProxy proxyPatQ) (mkProxy proxyTypeQ) un
 -- of types.
 
 -- TODO: parse a richer syntax for the types involved here so we can include spaces, applications, etc.
+{-# DEPRECATED
+      pr1
+      [ "'pr1' will be removed in the next release. Use 'Proxy' with @TypeApplications@ instead. "
+      , "Instead of using @[pr1|T|]@, use @Proxy \\@'[T]@ instead. "
+      ] #-}
 pr1 :: QuasiQuoter
 pr1 = QuasiQuoter (mkProxy proxyExpQ) (mkProxy proxyPatQ) (mkProxy proxyTypeQ) undefined where
   sing x = AppT (AppT PromotedConsT x) PromotedNilT


### PR DESCRIPTION
Its functionality has been subsumed by using `Proxy` with `TypeApplications` syntax. For instance, uses of `[pr|T|]` should be migrated to `Proxy @T`. `Data.Proxy.TH` will be removed in the next `tagged` release.

Towards #66.